### PR TITLE
Add box (and secretbox)

### DIFF
--- a/box.lua
+++ b/box.lua
@@ -1,0 +1,90 @@
+-- Copyright (c) 2017  Pierre Chapuis  -- see LICENSE file
+------------------------------------------------------------
+--[[
+
+High-level encryption routines
+
+]]
+
+local salsa20 = require "salsa20"
+local ec25519 = require "ec25519"
+local poly1305 = require "poly1305"
+
+local M
+
+local function randombytes(n)
+    -- Never use directly. Always use M.randombytes,
+    -- which can be overridden with a secure RNG.
+    local t = {}
+    for i = 1, n do t[i] = math.random(0, 255) end
+    return t
+end
+
+local function keypair()
+    local sk, pk = M.randombytes(32), {}
+    ec25519.crypto_scalarmult_base(pk, sk)
+    return string.char(table.unpack(pk)), string.char(table.unpack(sk))
+end
+
+local function unpack_nonce(nonce)
+    assert(#nonce == 24, "#nonce must be 24")
+    local nonce1 = nonce:sub(1, 8)
+    local counter = string.unpack("<I8", nonce:sub(9, 16))
+    local nonce2 = nonce:sub(17, 24)
+    return counter, nonce1, nonce2
+end
+
+local function secretbox(pt, nonce, key)
+    assert(#key == 32, "#key must be 32")
+    local counter, nonce1, nonce2 = unpack_nonce(nonce)
+    local key2 = salsa20.hsalsa20(key, counter, nonce1)
+    local et = salsa20.encrypt(key2, 0, nonce2, string.rep("\0", 32) .. pt)
+    local key3 = et:sub(1, 32)
+    et = et:sub(33)
+    local mac = poly1305.auth(et, key3)
+    return mac .. et
+end
+
+local function secretbox_open(et, nonce, key)
+    assert(#key == 32, "#key must be 32")
+    assert(#et >= 16, "#et must be at least 16")
+    local counter, nonce1, nonce2 = unpack_nonce(nonce)
+    local key2 = salsa20.hsalsa20(key, counter, nonce1)
+    local key3 = salsa20.stream(key2, 0, nonce1, 32)
+    local mac = et:sub(1, 16)
+    local mac2 = poly1305.auth(et:sub(17), key3)
+    if mac2 ~= mac then return nil, "invalid MAC" end
+    local pt = salsa20.encrypt(key2, 0, nonce2, string.rep("\0", 16) .. et)
+    return pt:sub(33)
+end
+
+local function stream_key(pk, sk)
+    assert(#pk == 32, "#pk must be 32")
+    assert(#sk == 32, "#pk must be 32")
+    pk = table.pack(pk:byte(1, 32))
+    sk = table.pack(sk:byte(1, 32))
+    local k = {}
+    ec25519.crypto_scalarmult(k, sk, pk)
+    k = string.char(table.unpack(k))
+    return salsa20.hsalsa20(k, 0, string.rep("\0", 8))
+ end
+
+local function box(pt, nonce, pk_b, sk_a)
+    return secretbox(pt, nonce, stream_key(pk_b, sk_a))
+end
+
+local function box_open(et, nonce, pk_a, sk_b)
+    return secretbox_open(et, nonce, stream_key(pk_a, sk_b))
+end
+
+M = {
+    randombytes = randombytes,
+    keypair = keypair,
+    secretbox = secretbox,
+    secretbox_open = secretbox_open,
+    stream_key = stream_key,
+    box = box,
+    box_open = box_open,
+}
+
+return M

--- a/salsa20.lua
+++ b/salsa20.lua
@@ -56,7 +56,7 @@ local salsa20_block = function(key, counter, nonce)
 	-- copy state to working_state
 	for i = 1, 16 do wst[i] = st[i] end
 	-- run 20 rounds, ie. 10 iterations of 8 quarter rounds
-	for i = 1, 10 do           --RFC reference:
+	for _ = 1, 10 do           --RFC reference:
 		qround(wst, 1,5,9,13)    --1.  QUARTERROUND ( 0, 4, 8,12)
 		qround(wst, 6,10,14,2)   --2.  QUARTERROUND ( 5, 9,13, 1)
 		qround(wst, 11,15,3,7)   --3.  QUARTERROUND (10,14, 2, 6)

--- a/salsa20.lua
+++ b/salsa20.lua
@@ -41,8 +41,8 @@ local salsa20_working_state = {0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0}
 
 local salsa20_block = function(key, counter, nonce)
 	-- key: u32[8]
-	-- counter: u32
-	-- nonce: u32[3]
+	-- counter: u32[2]
+	-- nonce: u32[2]
 	local st = salsa20_state 		-- state
 	local wst = salsa20_working_state 	-- working state
 	-- initialize state
@@ -52,7 +52,7 @@ local salsa20_block = function(key, counter, nonce)
 		st[i+1] = key[i]
 		st[i+11] = key[i+4]
 	end
-	st[7], st[8], st[9], st[10] = nonce[1], nonce[2], counter, 0
+	st[7], st[8], st[9], st[10] = nonce[1], nonce[2], counter[1], counter[2]
 	-- copy state to working_state
 	for i = 1, 16 do wst[i] = st[i] end
 	-- run 20 rounds, ie. 10 iterations of 8 quarter rounds
@@ -78,7 +78,7 @@ local pat16 = "<I4I4I4I4I4I4I4I4I4I4I4I4I4I4I4I4"
 local function salsa20_encrypt_block(key, counter, nonce, pt, ptidx)
 	-- encrypt a 64-byte block of plain text.
 	-- key: 32 bytes as an array of 8 uint32
-	-- counter: an uint32 (must be incremented for each block)
+	-- counter: 8 bytes as an array of 2 uint32
 	-- nonce: 8 bytes as an array of 2 uint32
 	-- pt: plain text string,
 	-- ptidx: index of beginning of block in plain text (origin=1)
@@ -108,24 +108,24 @@ end --salsa20_encrypt_block
 local salsa20_encrypt = function(key, counter, nonce, pt)
 	-- encrypt plain text 'pt', return encrypted text
 	-- key: 32 bytes as a string
-	-- counter: an uint32 (must be incremented for each block)
+	-- counter: an uint64 (must be incremented for each block)
 	-- nonce: 8 bytes as a string
 	-- pt: plain text string,
-
-	-- Ensure counter can fit an uint32 --although it's unlikely
-	-- that we hit this wall with pure Lua encryption :-)
-	assert((counter + #pt // 64 + 1) < 0xffffffff,
-		"block counter must fit an uint32")
 	assert(#key == 32, "#key must be 32")
 	assert(#nonce == 8, "#nonce must be 8")
 	local keya = table.pack(string.unpack("<I4I4I4I4I4I4I4I4", key))
 	local noncea = table.pack(string.unpack("<I4I4", nonce))
+	local countera = {counter & 0xffffffff, counter >> 32}
 	local t = {} -- used to collect all encrypted blocks
 	local ptidx = 1
 	while ptidx < #pt do
-		app(t, salsa20_encrypt_block(keya, counter, noncea, pt, ptidx))
+		app(t, salsa20_encrypt_block(keya, countera, noncea, pt, ptidx))
 		ptidx = ptidx + 64
-		counter = counter + 1
+		countera[1] = countera[1] + 1
+		if countera[1] > 0xffffffff then
+			countera[1] = 0
+			countera[2] = countera[2] + 1
+		end
 	end
 	local et = concat(t)
 	return et

--- a/test/test_box.lua
+++ b/test/test_box.lua
@@ -1,0 +1,20 @@
+local box = require "box"
+
+local pk_a, sk_a = box.keypair()
+local pk_b, sk_b = box.keypair()
+
+local k = ("k"):rep(32)
+local n = ("n"):rep(24)
+local pt = "abc"
+
+do
+    local et = assert(box.secretbox(pt, n, k))
+    local dt = assert(box.secretbox_open(et, n, k))
+    assert(dt == pt)
+end
+
+do
+    local et = assert(box.box(pt, n, pk_b, sk_a))
+    local dt = assert(box.box_open(et, n, pk_a, sk_b))
+    assert(dt == pt)
+end

--- a/test/test_salsa20.lua
+++ b/test/test_salsa20.lua
@@ -75,8 +75,26 @@ local function test_salsa20_ecrypt_6_0()
 	_test_salsa20_ecrypt(key, nonce, bytes, expected)
 end
 
+local function test_hsalsa20()
+	-- libsodium core2 test
+	local key = bin.hextos [[
+		1B27556473E985D462CD51197A9A46C7
+		6009549EAC6474F206C4EE0844F68389
+	]]
+	local nonce = bin.hextos("69696EE955B62B73")
+	local counter = string.unpack("<I8", (bin.hextos("CD62BDA875FC73D6")))
+	local expected = bin.hextos [[
+		DC908DDA0B9344A953629B7338207788
+		80F3CEB421BB61B91CBD4C3E66256CE4
+	]]
+	local key2 = salsa20.hsalsa20(key, counter, nonce)
+	assert(key2 == expected)
+end
+
 test_salsa20_encrypt_decrypt()
 test_salsa20_ecrypt_1_0()
 test_salsa20_ecrypt_6_0()
+test_hsalsa20()
 
 print("test_salsa20: ok")
+


### PR DESCRIPTION
This pull request:

- adds support for 64 bit salsa20 counters ;
- adds hsalsa20 and a method to generate salsa20 stream ;
- implements the `box` API (`secretbox`, `secretbox_open`, `box`, `box_open`).

For `box` I used the same API as [luatweetnacl](https://github.com/philanc/luatweetnacl) because it made it easier to test by comparison, not sure if you like it or not, feel free to change it otherwise!

Also note I left `randombytes` accessible in the module so the user can override it with something more secure, e.g. by reading from `/dev/urandom` (because there is no portable way to generate good random bytes in pure Lua). Alternatively, maybe `keypair` could take the secret key as an optional argument.